### PR TITLE
Fix eon merge wording in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ When using Eon via the Xray editor, command-line interaction should not be requi
 
 * `eon reset <version>` Switch the current branch to the specified state in the repository and replicate this change out to other replicas.
 
-* `eon merge <branch>` Merge the specified branch into the current branch. This only succeeds if the current branch shares a common ancestor with the current branch.
+* `eon merge <branch>` Merge the specified branch into the current branch. This only succeeds if the specified branch shares a common ancestor with the current branch.
 
 ## Xray integration
 


### PR DESCRIPTION
Clarify that for `eon merge` the _specified_ branch needs to have a common ancestor.